### PR TITLE
Inline non-template function definitions to appease ODR when including multiple times

### DIFF
--- a/parser.hpp
+++ b/parser.hpp
@@ -14,7 +14,7 @@ namespace aria {
     using CSV = std::vector<std::vector<std::string>>;
 
     // Checking for '\n', '\r', and '\r\n' by default
-    bool operator==(const char c, const Term t) {
+    inline bool operator==(const char c, const Term t) {
       switch (t) {
         case Term::CRLF:
           return c == '\r' || c == '\n';
@@ -23,7 +23,7 @@ namespace aria {
       }
     }
 
-    bool operator!=(const char c, const Term t) {
+    inline bool operator!=(const char c, const Term t) {
       return !(c == t);
     }
 


### PR DESCRIPTION
Using the library in multiple files within the same project will cause an ODR exception due to redefinition of  `operator==` and `operator!=` 

In-lining the definitions allows the library to be used more flexibly