### PR TITLE
Return by reference in parser functions to prevent copies

### DIFF
--- a/parser.hpp
+++ b/parser.hpp
@@ -82,19 +82,19 @@ namespace aria {
       }
 
       // Change the quote character
-      CsvParser quote(char c) noexcept {
+      CsvParser& quote(char c) noexcept {
         m_quote = c;
         return *this;
       }
 
       // Change the delimiter character
-      CsvParser delimiter(char c) noexcept {
+      CsvParser& delimiter(char c) noexcept {
         m_delimiter = c;
         return *this;
       }
 
       // Change the terminator character
-      CsvParser terminator(char c) noexcept {
+      CsvParser& terminator(char c) noexcept {
         m_terminator = static_cast<Term>(c);
         return *this;
       }


### PR DESCRIPTION
VCAnalyse is complaining as parser functions (.delimiter etc) are causing large stack allocations (131k, VCAnalyse limit is 16k)

This is due to the functions returning a needless copy of the parser object, not a reference.

Swapping to reference solves this.