### PR TITLE
Expose cursor position from the parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ as much memory as needed to represent a single row of your CSV. If that's too
 much, you can step down to a lower level, where you read from the CSV a field at
 a time, which only allocates the amount of memory needed for a single field.
 
+It is possible to inspect the current cursor position using ```parser.position()```.
+This will return the position of the last parsed token. This is useful when reporting
+things like progress through a file. Use ```file.seekg(0, std::ios::end);``` to get a
+file size.
+
 ```cpp
 #include <iostream>
 #include "./parser.hpp"

--- a/parser.hpp
+++ b/parser.hpp
@@ -82,13 +82,30 @@ namespace aria {
           throw std::runtime_error("Something is wrong with input stream");
         }
 
+        // Not all istreams are seekable (cin)
         m_input.seekg(0, std::ios::beg);
-        auto start = m_input.tellg();
-        m_input.seekg(0, std::ios::end);
-        auto finalpos = m_input.tellg();
-        m_input.seekg(0, std::ios::beg);
-
-        m_filesize = finalpos - start;
+        if(!m_input.fail())
+        {
+            auto start = m_input.tellg();
+            m_input.seekg(0, std::ios::end);
+            if(m_input.fail())
+            {
+                m_input.clear();
+                return;
+            }
+            auto finalpos = m_input.tellg();
+            m_input.seekg(0, std::ios::beg);
+            if(m_input.fail())
+            {
+                m_input.clear();
+                return;
+            }
+            m_filesize = finalpos - start;
+        }
+        else
+        {
+            m_input.clear();
+        }
       }
 
       // Change the quote character

--- a/parser.hpp
+++ b/parser.hpp
@@ -50,8 +50,6 @@ namespace aria {
         EMPTY
       };
       State m_state = State::START_OF_FIELD;
-      std::streamoff m_filesize = 0;
-      std::streamoff m_scanposition = -INPUTBUF_CAP;
 
       // Configurable attributes
       char m_quote = '"';
@@ -71,6 +69,7 @@ namespace aria {
       bool m_eof = false;
       size_t m_cursor = INPUTBUF_CAP;
       size_t m_inputbuf_size = INPUTBUF_CAP;
+      std::streamoff m_scanposition = -INPUTBUF_CAP;
     public:
       // Creates the CSV parser which by default, splits on commas,
       // uses quotes to escape, and handles CSV files that end in either
@@ -80,31 +79,6 @@ namespace aria {
         m_fieldbuf.reserve(FIELDBUF_CAP);
         if (!m_input.good()) {
           throw std::runtime_error("Something is wrong with input stream");
-        }
-
-        // Not all istreams are seekable (cin)
-        m_input.seekg(0, std::ios::beg);
-        if(!m_input.fail())
-        {
-            auto start = m_input.tellg();
-            m_input.seekg(0, std::ios::end);
-            if(m_input.fail())
-            {
-                m_input.clear();
-                return;
-            }
-            auto finalpos = m_input.tellg();
-            m_input.seekg(0, std::ios::beg);
-            if(m_input.fail())
-            {
-                m_input.clear();
-                return;
-            }
-            m_filesize = finalpos - start;
-        }
-        else
-        {
-            m_input.clear();
         }
       }
 
@@ -132,14 +106,9 @@ namespace aria {
         return m_state == State::EMPTY;
       }
 
-      std::streamoff filesize()
-      {
-          return m_filesize;
-      }
-
       // Not the actual position in the stream (its buffered) just the
       // position up to last availiable token
-      std::streamoff position()
+      std::streamoff position() const
       {
           return m_scanposition + static_cast<std::streamoff>(m_cursor);
       }


### PR DESCRIPTION
Expose cursor position so you can inspect progress of the parser.

The user is responsible for identifying the size of the content as it can be of unknown length (std:cin) instead of a file with a fixed size so the library provides no method to do this, only reports the parsers current cursor offset in the stream.