### PR TITLE
fix enum for arm compiling

### DIFF
--- a/parser.hpp
+++ b/parser.hpp
@@ -9,7 +9,7 @@
 
 namespace aria {
   namespace csv {
-    enum class Term : char { CRLF = -2 };
+    enum class Term : char { CRLF = 13 };
     enum class FieldType { DATA, ROW_END, CSV_END };
     using CSV = std::vector<std::vector<std::string>>;
 

--- a/parser.hpp
+++ b/parser.hpp
@@ -9,7 +9,7 @@
 
 namespace aria {
   namespace csv {
-    enum class Term : char { CRLF = 13 };
+    enum class Term { CRLF = -2 };
     enum class FieldType { DATA, ROW_END, CSV_END };
     using CSV = std::vector<std::vector<std::string>>;
 


### PR DESCRIPTION
# Issue
When cross-compiling for ARM using `arm-linux-gnueabihf-g++`, the following error would arise:
```
lib/csv-parser/parser.hpp:12:38: error: enumerator value -2 is outside the range of underlying type ‘char’
     enum class Term : char { CRLF = -2 };
```
# Fix
Changed the CRLF enum from `-2` to `13` to be the `\r` character regardless of enum size.
