### PR TITLE
Add missing `static_cast`

### DIFF
--- a/parser.hpp
+++ b/parser.hpp
@@ -246,7 +246,7 @@ namespace aria {
           // input buffer to show that it's not at full capacity
           if (m_input.eof()) {
             m_eof = true;
-            m_inputbuf_size = m_input.gcount();
+            m_inputbuf_size = static_cast<size_t>(m_input.gcount());
 
             // Return null if there's nothing left to read
             if (m_inputbuf_size == 0) {


### PR DESCRIPTION
First thank you for making/sharing this library, it works great so far! However, when compiling with `-Werror -Wsign-conversion`, I'm getting a compiler error due to an implicit `std::streamsize` -> `size_t` conversion. Making the conversion explicit with a (presumably forgotten) `static_cast` fixes this.